### PR TITLE
Add server-side friends: Witness lookup, requests & lifecycle in API …

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,39 @@
+# My Pact
+
+Domain glossary for My Pact — a social habit-tracking app where friends witness
+and hold each other accountable to time-boxed commitments.
+
+## Friendship
+
+**Friendship**:
+The bond between two users. Undirected — at most one friendship exists per
+unordered pair of users — even though a row records who asked (see Requester /
+Addressee). Its status is `pending`, `accepted`, `declined`, or `blocked`.
+_Avoid_: "friend request" for the stored record — a request is just a *pending*
+friendship, not a separate entity.
+
+**Requester**:
+The user who initiated a friendship. A storage role that captures direction; it
+does not make the relationship directional.
+
+**Addressee**:
+The user a friendship request was sent to — the one who accepts or declines.
+
+**Incoming request**:
+A pending friendship seen from the addressee's side (someone asked *me*).
+_Avoid_: "received request".
+
+**Outgoing request**:
+A pending friendship seen from the requester's side (I asked *them*).
+_Avoid_: "sent request".
+
+**Witness**:
+The product word for a friend — someone bound to you who can see and vouch for
+your pacts. The Friends screen labels the accepted list "Witnesses".
+_Avoid_: follower, contact.
+
+**Keeper**:
+The one friend a given pact names as its accountability holder. Narrower than a
+Witness: every keeper is a friend, but a keeper is scoped to a single pact.
+_Avoid_: using "witness" for this role — a keeper is a specific job on a pact,
+not the general bond.

--- a/docs/adr/0002-friendship-unordered-pair.md
+++ b/docs/adr/0002-friendship-unordered-pair.md
@@ -1,0 +1,57 @@
+# ADR 0002: One friendship per unordered pair, enforced by a partial expression index
+
+Date: 2026-07-01
+Status: accepted
+
+## Context
+
+`friendships` stores a direction (requester → addressee) so the UI can show a
+pending request as "incoming" vs "outgoing". But the underlying relationship is
+*undirected*: there should be at most one friendship between two users,
+regardless of who asked. The client store already enforces this in app code —
+its duplicate check rejects a new request when a friendship exists in **either**
+direction and is not `declined` (`src/store/use-store.ts`). The server needs the
+same guarantee, and it needs it to survive races (two users requesting each
+other at the same instant) that app-level checks alone cannot close.
+
+Two existing behaviours must be preserved:
+
+- Re-requesting someone who previously **declined** you is allowed — a declined
+  row is a tombstone, not a permanent block.
+- A **removed** friend (soft-deleted via `deleted_at`) can be re-added later.
+
+The `friendships` table itself already existed (migration `0000`); what was
+missing was any uniqueness constraint on the pair.
+
+## Decision
+
+Enforce the invariant with a single partial, undirected unique index:
+
+```sql
+UNIQUE (LEAST(requester_id, addressee_id), GREATEST(requester_id, addressee_id))
+WHERE status <> 'declined' AND deleted_at IS NULL
+```
+
+`LEAST/GREATEST` canonicalise the unordered pair; the predicate lets declined
+tombstones and soft-deleted rows coexist with a fresh live row. The send route
+inserts optimistically and treats a unique violation (SQLSTATE `23505`) as the
+`duplicate` result, so concurrent cross-requests collapse to one friendship.
+The index ships in a new migration; the table is untouched.
+
+## Considered options
+
+- **Directed unique `(requester_id, addressee_id)`** — the literal reading of
+  "unique on the pair". Rejected: it allows `A→B` and `B→A` to coexist and it
+  blocks the legitimate re-request-after-decline. It enforces the wrong
+  invariant.
+- **App-level dedup only** (mirror the store, no DB constraint). Rejected: it
+  double-inserts under a race and lets the database hold states the domain
+  forbids.
+
+## Consequences
+
+- The index predicate `status <> 'declined'` is intentionally identical to the
+  store's dedup rule, so client and server agree on what "duplicate" means.
+- The send route must catch `23505` and map it to `duplicate` rather than 500.
+- `drizzle-kit`'s diffing of expression/partial indexes is imperfect, so the
+  generated migration SQL is hand-verified.

--- a/docs/adr/0003-client-identity-sentinel.md
+++ b/docs/adr/0003-client-identity-sentinel.md
@@ -1,0 +1,47 @@
+# ADR 0003: Client identity stays the `'u-me'` sentinel; the server orients domain rows
+
+Date: 2026-07-01
+Status: accepted
+
+## Context
+
+In API mode the client keeps `meId` as the constant sentinel `'u-me'` and
+discards the signed-in user's real (Better Auth) id — `updateProfile` copies the
+server profile's name/email/timezone into the local me-user but never its id
+(`src/store/use-store.ts`, `src/app/login.tsx`, `src/app/_layout.tsx`). Server
+domain rows (friendships now; pacts/check-ins/notifications later) are keyed by
+the real user id, so they cannot be dropped into the client store as-is: the
+selectors locate "me" by matching `'u-me'`, so raw server rows match nothing and
+the lists render empty.
+
+## Decision
+
+The server orients each row to the requesting user and returns only the
+*counterpart's* profile; the client stitches the local side to `'u-me'`. For
+friends, `GET /friends` returns `{ friends, incoming, outgoing }`, each item
+carrying the friendship id/status/createdAt plus the counterpart `user` profile.
+The client rebuilds client-shaped rows with the local side hardcoded to `'u-me'`
+and caches counterparts (by their real server id) in `users`. The existing
+selectors are unchanged.
+
+We explicitly do **not** adopt the server id as `meId`.
+
+## Considered options
+
+- **Adopt the server id as `meId` on sign-in.** Rejected for this slice: it
+  needs a new "adopt identity" action (`updateProfile` is keyed on id) and
+  touches the auth flow, the `ME` constant, `resetLocal`, `buildBareState`, and
+  persisted state that locally-created pacts/check-ins/notifications reference —
+  a large blast radius to entangle with a single feature.
+
+## Consequences
+
+- Cached `requesterId`/`addresseeId` are synthetic (the local side is always
+  `'u-me'`); nothing client-side reads the server's real requester/addressee
+  ids. The friendship id (a server uuid) is what accept/decline calls use.
+- This is the precedent for all domain sync: pacts, check-ins and notifications
+  should orient server-side and stitch to `'u-me'` the same way, rather than
+  each adopting the server id independently.
+- If a future feature genuinely needs the client to know its own server id,
+  revisit this — adopting the server id becomes the cleaner model once identity
+  plumbing is centralised.

--- a/drizzle/0001_milky_hulk.sql
+++ b/drizzle/0001_milky_hulk.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "friendships_pair_unique" ON "friendships" USING btree (least("requester_id", "addressee_id"),greatest("requester_id", "addressee_id")) WHERE "friendships"."status" <> 'declined' AND "friendships"."deleted_at" IS NULL;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1053 @@
+{
+  "id": "07144a1f-2c05-43d5-b3f7-4f05738d34f0",
+  "prevId": "024f7453-9889-41b4-9b00-d7e9753aeebd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.check_ins": {
+      "name": "check_ins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pact_id": {
+          "name": "pact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "check_in_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress_value": {
+          "name": "progress_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "check_ins_pact_user_date_unique": {
+          "name": "check_ins_pact_user_date_unique",
+          "columns": [
+            {
+              "expression": "pact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "check_ins_pact_id_pacts_id_fk": {
+          "name": "check_ins_pact_id_pacts_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "pacts",
+          "columnsFrom": [
+            "pact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "check_ins_user_id_user_id_fk": {
+          "name": "check_ins_user_id_user_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "friendship_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "friendships_requester_idx": {
+          "name": "friendships_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_addressee_idx": {
+          "name": "friendships_addressee_idx",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_pair_unique": {
+          "name": "friendships_pair_unique",
+          "columns": [
+            {
+              "expression": "least(\"requester_id\", \"addressee_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "greatest(\"requester_id\", \"addressee_id\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"friendships\".\"status\" <> 'declined' AND \"friendships\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_requester_id_user_id_fk": {
+          "name": "friendships_requester_id_user_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_addressee_id_user_id_fk": {
+          "name": "friendships_addressee_id_user_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "friendships_not_self": {
+          "name": "friendships_not_self",
+          "value": "\"friendships\".\"requester_id\" <> \"friendships\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pact_id": {
+          "name": "pact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_idx": {
+          "name": "notifications_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_pact_id_pacts_id_fk": {
+          "name": "notifications_pact_id_pacts_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "pacts",
+          "columnsFrom": [
+            "pact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_friend_id_user_id_fk": {
+          "name": "notifications_friend_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pacts": {
+      "name": "pacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keeper_user_id": {
+          "name": "keeper_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "pact_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pact_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "smallint[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_target": {
+          "name": "goal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_unit": {
+          "name": "goal_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mutual": {
+          "name": "is_mutual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mutual_pact_id": {
+          "name": "mutual_pact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tint_index": {
+          "name": "tint_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pacts_creator_idx": {
+          "name": "pacts_creator_idx",
+          "columns": [
+            {
+              "expression": "creator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pacts_keeper_idx": {
+          "name": "pacts_keeper_idx",
+          "columns": [
+            {
+              "expression": "keeper_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pacts_mutual_idx": {
+          "name": "pacts_mutual_idx",
+          "columns": [
+            {
+              "expression": "mutual_pact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pacts_creator_user_id_user_id_fk": {
+          "name": "pacts_creator_user_id_user_id_fk",
+          "tableFrom": "pacts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pacts_keeper_user_id_user_id_fk": {
+          "name": "pacts_keeper_user_id_user_id_fk",
+          "tableFrom": "pacts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "keeper_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "notification_time": {
+          "name": "notification_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'08:00'"
+        },
+        "tint_index": {
+          "name": "tint_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.check_in_status": {
+      "name": "check_in_status",
+      "schema": "public",
+      "values": [
+        "completed",
+        "failed"
+      ]
+    },
+    "public.friendship_status": {
+      "name": "friendship_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "blocked"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "daily_reminder",
+        "friend_request",
+        "friend_accepted",
+        "pact_breach",
+        "pact_completed"
+      ]
+    },
+    "public.pact_status": {
+      "name": "pact_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "incomplete",
+        "cancelled"
+      ]
+    },
+    "public.pact_type": {
+      "name": "pact_type",
+      "schema": "public",
+      "values": [
+        "frequency",
+        "goal"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1781180691571,
       "tag": "0000_fair_starjammers",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1782904221940,
+      "tag": "0001_milky_hulk",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,8 @@
         "eslint": "^9.0.0",
         "eslint-config-expo": "~56.0.4",
         "tsx": "^4.22.4",
-        "typescript": "~6.0.3"
+        "typescript": "~6.0.3",
+        "vitest": "^3.2.6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4235,6 +4236,370 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4365,11 +4730,29 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/hammerjs": {
@@ -5063,6 +5446,121 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -5400,6 +5898,16 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -5855,6 +6363,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -5947,6 +6465,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5961,6 +6496,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chrome-launcher": {
@@ -6385,6 +6930,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -6900,6 +7455,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -7565,6 +8127,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7591,6 +8163,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/expo": {
@@ -10263,6 +10845,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -10280,6 +10869,16 @@
       "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/makeerror": {
@@ -11390,6 +11989,23 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -12218,6 +12834,51 @@
         "node": ">=4"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rou3": {
       "version": "0.7.12",
       "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
@@ -12622,6 +13283,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -12716,6 +13384,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -12748,6 +13423,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -12941,6 +13623,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/structured-headers": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-0.4.1.tgz",
@@ -13036,6 +13738,20 @@
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -13050,6 +13766,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmpl": {
@@ -14016,6 +14762,635 @@
         "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vlq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
@@ -14176,6 +15551,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "eslint": "^9.0.0",
     "eslint-config-expo": "~56.0.4",
     "tsx": "^4.22.4",
-    "typescript": "~6.0.3"
+    "typescript": "~6.0.3",
+    "vitest": "^3.2.6"
   },
   "scripts": {
     "start": "expo start",
@@ -59,7 +60,8 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "lint": "expo lint",
-    "api": "tsx watch server/index.ts",
+    "api": "tsx watch --env-file=.env.local server/index.ts",
+    "test": "vitest run",
     "auth:schema": "npx -y @better-auth/cli@latest generate --config server/auth.ts --output server/db/auth-schema.ts -y",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate"

--- a/server/app.ts
+++ b/server/app.ts
@@ -5,6 +5,7 @@ import { logger } from 'hono/logger';
 import { auth } from './auth';
 import type { AppEnv } from './context';
 import { env } from './env';
+import { friends } from './routes/friends';
 import { users } from './routes/users';
 
 // Everything lives under /api: Vercel routes only api/ functions, so the
@@ -47,3 +48,4 @@ app.use('*', async (c, next) => {
 });
 
 app.route('/users', users);
+app.route('/friends', friends);

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -5,6 +5,8 @@ import { env } from '../env';
 import * as schema from './schema';
 
 // prepare: false — required for Supabase's transaction-mode pooler in production.
-const client = postgres(env.databaseUrl, { prepare: false });
+// Exported so tests can close the connection pool after the suite (otherwise
+// the open postgres-js handle keeps Vitest's worker alive and the run hangs).
+export const client = postgres(env.databaseUrl, { prepare: false });
 
 export const db = drizzle(client, { schema });

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -70,6 +70,16 @@ export const friendships = pgTable(
     index('friendships_requester_idx').on(t.requesterId),
     index('friendships_addressee_idx').on(t.addresseeId),
     check('friendships_not_self', sql`${t.requesterId} <> ${t.addresseeId}`),
+    // ADR 0002: one friendship per *unordered* pair. LEAST/GREATEST canonicalise
+    // the pair so A→B and B→A collide; the partial predicate lets declined
+    // tombstones and soft-deleted rows coexist with a fresh live row
+    // (re-request-after-decline and re-add-after-remove stay legal).
+    uniqueIndex('friendships_pair_unique')
+      .on(
+        sql`least(${t.requesterId}, ${t.addresseeId})`,
+        sql`greatest(${t.requesterId}, ${t.addresseeId})`
+      )
+      .where(sql`${t.status} <> 'declined' AND ${t.deletedAt} IS NULL`),
   ]
 );
 

--- a/server/routes/friends.test.ts
+++ b/server/routes/friends.test.ts
@@ -1,0 +1,553 @@
+import { randomUUID } from 'node:crypto';
+
+import { and, eq, isNull, ne, or } from 'drizzle-orm';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { auth } from '../auth';
+import { db } from '../db';
+import { friendships, user } from '../db/schema';
+import { api, asAnon, asUser, cleanupCreated, seedUser, trackFriendship } from '../test/harness';
+
+type UserRow = typeof user.$inferSelect;
+type SendBody = { result: 'not_found' | 'self' | 'duplicate' | 'sent' };
+type FriendItem = {
+  friendshipId: string;
+  status: string;
+  createdAt: string;
+  user: {
+    id: string;
+    username: string;
+    email: string;
+    timezone: string;
+    notificationTime: string;
+    tintIndex: number;
+  };
+};
+type Graph = { friends: FriendItem[]; incoming: FriendItem[]; outgoing: FriendItem[] };
+
+// ── Pair helpers ─────────────────────────────────────────────────────────────
+
+/** Live (non-declined, non-soft-deleted) friendship rows for an unordered pair. */
+function livePairRows(a: string, b: string) {
+  return db
+    .select()
+    .from(friendships)
+    .where(
+      and(
+        or(
+          and(eq(friendships.requesterId, a), eq(friendships.addresseeId, b)),
+          and(eq(friendships.requesterId, b), eq(friendships.addresseeId, a))
+        ),
+        ne(friendships.status, 'declined'),
+        isNull(friendships.deletedAt)
+      )
+    );
+}
+
+/** Every friendship row for an unordered pair, regardless of status/soft-delete. */
+function allPairRows(a: string, b: string) {
+  return db
+    .select()
+    .from(friendships)
+    .where(
+      or(
+        and(eq(friendships.requesterId, a), eq(friendships.addresseeId, b)),
+        and(eq(friendships.requesterId, b), eq(friendships.addresseeId, a))
+      )
+    );
+}
+
+/** Read a single friendship row by id (regardless of status/soft-delete). */
+async function rowById(id: string) {
+  const [row] = await db.select().from(friendships).where(eq(friendships.id, id)).limit(1);
+  return row;
+}
+
+/**
+ * Resolve each request to a different user by its bearer token. The global
+ * asUser() mock represents a single identity; concurrent cross-requests
+ * (A→B and B→A at once) need the session resolved per request instead.
+ */
+function asUsersByToken(users: UserRow[]): void {
+  const byToken = new Map<string, UserRow>(users.map((u) => [`test-token-${u.id}`, u]));
+  vi.spyOn(auth.api, 'getSession').mockImplementation((async (opts: { headers: Headers }) => {
+    const token = (opts.headers.get('authorization') ?? '').replace(/^Bearer\s+/i, '');
+    const u = byToken.get(token);
+    if (!u) return null;
+    return {
+      user: u,
+      session: {
+        id: `test-session-${u.id}`,
+        userId: u.id,
+        token,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      },
+    };
+  }) as unknown as typeof auth.api.getSession);
+}
+
+const tokenFor = (u: UserRow) => `test-token-${u.id}`;
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('friends routes', () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanupCreated();
+  });
+
+  describe('POST /friends/requests — result mapping', () => {
+    it('returns not_found for an email that belongs to nobody', async () => {
+      const me = await seedUser();
+      asUser(me);
+      const { status, json } = await api('/friends/requests', {
+        method: 'POST',
+        body: { email: `nobody-${randomUUID()}@example.test` },
+      });
+      expect(status).toBe(200);
+      await expect(json<SendBody>().then((b) => b.result)).resolves.toBe('not_found');
+    });
+
+    it('returns self for the caller’s own email (and a case variant of it)', async () => {
+      const me = await seedUser({ email: `Self-${randomUUID().slice(0, 8)}@Example.test` });
+      asUser(me);
+
+      const exact = await api('/friends/requests', { method: 'POST', body: { email: me.email } });
+      await expect(exact.json<SendBody>().then((b) => b.result)).resolves.toBe('self');
+
+      const variant = await api('/friends/requests', {
+        method: 'POST',
+        body: { email: me.email.toUpperCase() },
+      });
+      await expect(variant.json<SendBody>().then((b) => b.result)).resolves.toBe('self');
+    });
+
+    it('returns sent for a fresh request and writes exactly one pending row', async () => {
+      const me = await seedUser();
+      const target = await seedUser();
+      asUser(me);
+
+      const { status, json } = await api('/friends/requests', {
+        method: 'POST',
+        body: { email: target.email },
+      });
+      expect(status).toBe(200);
+      await expect(json<SendBody>().then((b) => b.result)).resolves.toBe('sent');
+
+      const rows = await livePairRows(me.id, target.id);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].requesterId).toBe(me.id);
+      expect(rows[0].addresseeId).toBe(target.id);
+      expect(rows[0].status).toBe('pending');
+      trackFriendship(rows[0].id);
+    });
+
+    it('matches the target case-insensitively (seed Foo@Bar.com, request foo@bar.com)', async () => {
+      const me = await seedUser();
+      const target = await seedUser({ email: `Foo-${randomUUID().slice(0, 8)}@Bar.com` });
+      asUser(me);
+
+      const { json } = await api('/friends/requests', {
+        method: 'POST',
+        body: { email: target.email.toLowerCase() },
+      });
+      await expect(json<SendBody>().then((b) => b.result)).resolves.toBe('sent');
+
+      const rows = await livePairRows(me.id, target.id);
+      expect(rows).toHaveLength(1);
+      trackFriendship(rows[0].id);
+    });
+
+    it('returns duplicate for a second request to the same target', async () => {
+      const me = await seedUser();
+      const target = await seedUser();
+      asUser(me);
+
+      const first = await api('/friends/requests', { method: 'POST', body: { email: target.email } });
+      await expect(first.json<SendBody>().then((b) => b.result)).resolves.toBe('sent');
+
+      const second = await api('/friends/requests', { method: 'POST', body: { email: target.email } });
+      await expect(second.json<SendBody>().then((b) => b.result)).resolves.toBe('duplicate');
+
+      expect(await livePairRows(me.id, target.id)).toHaveLength(1);
+    });
+
+    it('returns 400 when the email is missing or the wrong type', async () => {
+      const me = await seedUser();
+      asUser(me);
+
+      const missing = await api('/friends/requests', { method: 'POST', body: {} });
+      expect(missing.status).toBe(400);
+
+      const wrongType = await api('/friends/requests', { method: 'POST', body: { email: 42 } });
+      expect(wrongType.status).toBe(400);
+
+      const blank = await api('/friends/requests', { method: 'POST', body: { email: '   ' } });
+      expect(blank.status).toBe(400);
+    });
+  });
+
+  describe('undirected-pair invariant (ADR 0002, against real Postgres)', () => {
+    it('collapses a duplicate in EITHER direction to one live friendship', async () => {
+      const a = await seedUser();
+      const b = await seedUser();
+
+      asUser(a);
+      const forward = await api('/friends/requests', { method: 'POST', body: { email: b.email } });
+      await expect(forward.json<SendBody>().then((r) => r.result)).resolves.toBe('sent');
+
+      asUser(b);
+      const reverse = await api('/friends/requests', { method: 'POST', body: { email: a.email } });
+      await expect(reverse.json<SendBody>().then((r) => r.result)).resolves.toBe('duplicate');
+
+      expect(await livePairRows(a.id, b.id)).toHaveLength(1);
+    });
+
+    it('allows a re-request after a decline (tombstone coexists with a fresh row)', async () => {
+      const a = await seedUser();
+      const b = await seedUser();
+
+      asUser(a);
+      const first = await api('/friends/requests', { method: 'POST', body: { email: b.email } });
+      await expect(first.json<SendBody>().then((r) => r.result)).resolves.toBe('sent');
+
+      const [pending] = await livePairRows(a.id, b.id);
+      expect(pending).toBeDefined();
+      await db.update(friendships).set({ status: 'declined' }).where(eq(friendships.id, pending.id));
+      trackFriendship(pending.id);
+
+      asUser(a);
+      const second = await api('/friends/requests', { method: 'POST', body: { email: b.email } });
+      await expect(second.json<SendBody>().then((r) => r.result)).resolves.toBe('sent');
+
+      const live = await livePairRows(a.id, b.id);
+      expect(live).toHaveLength(1);
+      expect(live[0].id).not.toBe(pending.id);
+      trackFriendship(live[0].id);
+
+      // The declined tombstone and the new live row coexist.
+      expect(await allPairRows(a.id, b.id)).toHaveLength(2);
+    });
+
+    it('collapses two CONCURRENT cross-requests to one (23505 → duplicate)', async () => {
+      const a = await seedUser();
+      const b = await seedUser();
+      asUsersByToken([a, b]);
+
+      const [ra, rb] = await Promise.all([
+        api('/friends/requests', { method: 'POST', token: tokenFor(a), body: { email: b.email } }),
+        api('/friends/requests', { method: 'POST', token: tokenFor(b), body: { email: a.email } }),
+      ]);
+
+      // Neither may 500: the unique-violation path must map to `duplicate`.
+      expect(ra.status).toBe(200);
+      expect(rb.status).toBe(200);
+
+      const results = [
+        (await ra.json<SendBody>()).result,
+        (await rb.json<SendBody>()).result,
+      ].sort();
+      expect(results).toEqual(['duplicate', 'sent']);
+
+      expect(await livePairRows(a.id, b.id)).toHaveLength(1);
+    });
+  });
+
+  describe('GET /friends — orientation from the session user’s side', () => {
+    it('partitions accepted/incoming/outgoing, carries the counterpart, excludes soft-deleted', async () => {
+      const me = await seedUser({ name: 'Me' });
+      const alice = await seedUser({ name: 'Alice' });
+      const bob = await seedUser({ name: 'Bob' });
+      const carol = await seedUser({ name: 'Carol' });
+      const dave = await seedUser({ name: 'Dave' });
+
+      const [accepted] = await db
+        .insert(friendships)
+        .values({ requesterId: me.id, addresseeId: alice.id, status: 'accepted' })
+        .returning();
+      const [incoming] = await db
+        .insert(friendships)
+        .values({ requesterId: bob.id, addresseeId: me.id, status: 'pending' })
+        .returning();
+      const [outgoing] = await db
+        .insert(friendships)
+        .values({ requesterId: me.id, addresseeId: carol.id, status: 'pending' })
+        .returning();
+      const [softDeleted] = await db
+        .insert(friendships)
+        .values({ requesterId: me.id, addresseeId: dave.id, status: 'accepted', deletedAt: new Date() })
+        .returning();
+      [accepted, incoming, outgoing, softDeleted].forEach((r) => trackFriendship(r.id));
+
+      asUser(me);
+      const { status, json } = await api('/friends');
+      expect(status).toBe(200);
+      const graph = await json<Graph>();
+
+      expect(graph.friends).toHaveLength(1);
+      expect(graph.friends[0].friendshipId).toBe(accepted.id);
+      expect(graph.friends[0].status).toBe('accepted');
+      expect(graph.friends[0].user.id).toBe(alice.id);
+      expect(graph.friends[0].user.username).toBe('Alice');
+      expect(graph.friends[0].user.email).toBe(alice.email);
+
+      expect(graph.incoming).toHaveLength(1);
+      expect(graph.incoming[0].friendshipId).toBe(incoming.id);
+      expect(graph.incoming[0].status).toBe('pending');
+      expect(graph.incoming[0].user.id).toBe(bob.id);
+
+      expect(graph.outgoing).toHaveLength(1);
+      expect(graph.outgoing[0].friendshipId).toBe(outgoing.id);
+      expect(graph.outgoing[0].status).toBe('pending');
+      expect(graph.outgoing[0].user.id).toBe(carol.id);
+
+      const everyone = [...graph.friends, ...graph.incoming, ...graph.outgoing];
+      // Every item carries the counterpart, never the caller.
+      for (const item of everyone) expect(item.user.id).not.toBe(me.id);
+      // The soft-deleted row is excluded entirely.
+      expect(everyone.map((i) => i.user.id)).not.toContain(dave.id);
+    });
+  });
+
+  describe('auth guard', () => {
+    it('returns 401 for GET /friends without a session', async () => {
+      asAnon();
+      const { status } = await api('/friends');
+      expect(status).toBe(401);
+    });
+
+    it('returns 401 for POST /friends/requests without a session', async () => {
+      asAnon();
+      const { status } = await api('/friends/requests', {
+        method: 'POST',
+        body: { email: 'someone@example.test' },
+      });
+      expect(status).toBe(401);
+    });
+  });
+
+  // ── Issue #4: accept or decline an incoming request (become Witnesses) ──────
+  describe('POST /friends/:id/accept & /decline — addressee-only', () => {
+    /** Seed requester A + addressee B with a fresh pending A→B row. */
+    async function seedPending() {
+      const a = await seedUser({ name: 'Requester' });
+      const b = await seedUser({ name: 'Addressee' });
+      const [pending] = await db
+        .insert(friendships)
+        .values({ requesterId: a.id, addresseeId: b.id, status: 'pending' })
+        .returning();
+      trackFriendship(pending.id);
+      return { a, b, pending };
+    }
+
+    it('accept turns the pending request into a mutual friendship', async () => {
+      const { a, b, pending } = await seedPending();
+
+      asUser(b);
+      const accept = await api(`/friends/${pending.id}/accept`, { method: 'POST' });
+      expect(accept.status).toBe(200);
+      expect((await rowById(pending.id)).status).toBe('accepted');
+
+      // Mutual: each participant sees the OTHER under `friends`, and the
+      // request has left the incoming/outgoing buckets for both.
+      asUser(a);
+      const graphA = await (await api('/friends')).json<Graph>();
+      expect(graphA.friends.map((f) => f.user.id)).toContain(b.id);
+      expect(graphA.friends.find((f) => f.user.id === b.id)?.status).toBe('accepted');
+      expect(graphA.incoming).toHaveLength(0);
+      expect(graphA.outgoing).toHaveLength(0);
+
+      asUser(b);
+      const graphB = await (await api('/friends')).json<Graph>();
+      expect(graphB.friends.map((f) => f.user.id)).toContain(a.id);
+      expect(graphB.friends.find((f) => f.user.id === a.id)?.status).toBe('accepted');
+      expect(graphB.incoming).toHaveLength(0);
+    });
+
+    it('decline lets the requester ask again (tombstone coexists with a fresh row)', async () => {
+      const { a, b, pending } = await seedPending();
+
+      asUser(b);
+      const decline = await api(`/friends/${pending.id}/decline`, { method: 'POST' });
+      expect(decline.status).toBe(200);
+      expect((await rowById(pending.id)).status).toBe('declined');
+      // A declined request never appears in either side's graph.
+      const graphB = await (await api('/friends')).json<Graph>();
+      expect(graphB.incoming).toHaveLength(0);
+
+      asUser(a);
+      const resend = await api('/friends/requests', { method: 'POST', body: { email: b.email } });
+      await expect(resend.json<SendBody>().then((r) => r.result)).resolves.toBe('sent');
+
+      const live = await livePairRows(a.id, b.id);
+      expect(live).toHaveLength(1);
+      expect(live[0].id).not.toBe(pending.id);
+      trackFriendship(live[0].id);
+      // Declined tombstone + fresh live row coexist.
+      expect(await allPairRows(a.id, b.id)).toHaveLength(2);
+    });
+
+    it('rejects the requester answering their own request (403)', async () => {
+      const { a, pending } = await seedPending();
+      asUser(a);
+      expect((await api(`/friends/${pending.id}/accept`, { method: 'POST' })).status).toBe(403);
+      expect((await api(`/friends/${pending.id}/decline`, { method: 'POST' })).status).toBe(403);
+      // The row is untouched.
+      expect((await rowById(pending.id)).status).toBe('pending');
+    });
+
+    it('rejects an outsider (403)', async () => {
+      const { pending } = await seedPending();
+      const outsider = await seedUser({ name: 'Outsider' });
+      asUser(outsider);
+      expect((await api(`/friends/${pending.id}/accept`, { method: 'POST' })).status).toBe(403);
+      expect((await api(`/friends/${pending.id}/decline`, { method: 'POST' })).status).toBe(403);
+      expect((await rowById(pending.id)).status).toBe('pending');
+    });
+
+    it('returns 404 for an unknown or soft-deleted friendship', async () => {
+      const a = await seedUser();
+      const b = await seedUser();
+      asUser(b);
+
+      const unknown = randomUUID();
+      expect((await api(`/friends/${unknown}/accept`, { method: 'POST' })).status).toBe(404);
+      expect((await api(`/friends/${unknown}/decline`, { method: 'POST' })).status).toBe(404);
+
+      const [gone] = await db
+        .insert(friendships)
+        .values({ requesterId: a.id, addresseeId: b.id, status: 'pending', deletedAt: new Date() })
+        .returning();
+      trackFriendship(gone.id);
+      expect((await api(`/friends/${gone.id}/accept`, { method: 'POST' })).status).toBe(404);
+      expect((await api(`/friends/${gone.id}/decline`, { method: 'POST' })).status).toBe(404);
+    });
+
+    it('returns 404 once the request is no longer pending (already answered)', async () => {
+      const { b, pending } = await seedPending();
+      asUser(b);
+      // The addressee answers it once…
+      expect((await api(`/friends/${pending.id}/accept`, { method: 'POST' })).status).toBe(200);
+      // …so there is no longer a pending request to accept or decline. This also
+      // stops a declined tombstone from being resurrected into a duplicate bond.
+      expect((await api(`/friends/${pending.id}/accept`, { method: 'POST' })).status).toBe(404);
+      expect((await api(`/friends/${pending.id}/decline`, { method: 'POST' })).status).toBe(404);
+      // The already-accepted bond is untouched by the rejected calls.
+      expect((await rowById(pending.id)).status).toBe('accepted');
+    });
+
+    it('returns 401 without a session', async () => {
+      asAnon();
+      const id = randomUUID();
+      expect((await api(`/friends/${id}/accept`, { method: 'POST' })).status).toBe(401);
+      expect((await api(`/friends/${id}/decline`, { method: 'POST' })).status).toBe(401);
+    });
+  });
+
+  // ── Issue #5: block or remove a bond, and re-add later ──────────────────────
+  describe('POST /friends/:id/block & DELETE /friends/:id — participant-only', () => {
+    /** Seed an accepted A↔B bond (requester A, addressee B). */
+    async function seedAccepted() {
+      const a = await seedUser({ name: 'A' });
+      const b = await seedUser({ name: 'B' });
+      const [bond] = await db
+        .insert(friendships)
+        .values({ requesterId: a.id, addresseeId: b.id, status: 'accepted' })
+        .returning();
+      trackFriendship(bond.id);
+      return { a, b, bond };
+    }
+
+    it('remove soft-deletes the bond and hides it from both sides', async () => {
+      const { a, b, bond } = await seedAccepted();
+
+      asUser(a);
+      const del = await api(`/friends/${bond.id}`, { method: 'DELETE' });
+      expect(del.status).toBe(200);
+
+      const row = await rowById(bond.id);
+      expect(row.deletedAt).not.toBeNull();
+
+      asUser(a);
+      const graphA = await (await api('/friends')).json<Graph>();
+      expect(graphA.friends.map((f) => f.user.id)).not.toContain(b.id);
+
+      asUser(b);
+      const graphB = await (await api('/friends')).json<Graph>();
+      expect(graphB.friends.map((f) => f.user.id)).not.toContain(a.id);
+    });
+
+    it('a removed friend can be re-added — a new live row joins the tombstone', async () => {
+      const { a, b, bond } = await seedAccepted();
+
+      asUser(a);
+      expect((await api(`/friends/${bond.id}`, { method: 'DELETE' })).status).toBe(200);
+
+      const resend = await api('/friends/requests', { method: 'POST', body: { email: b.email } });
+      await expect(resend.json<SendBody>().then((r) => r.result)).resolves.toBe('sent');
+
+      const live = await livePairRows(a.id, b.id);
+      expect(live).toHaveLength(1);
+      expect(live[0].id).not.toBe(bond.id);
+      trackFriendship(live[0].id);
+
+      // Two rows for the pair: the soft-deleted tombstone and the fresh live one.
+      const all = await allPairRows(a.id, b.id);
+      expect(all).toHaveLength(2);
+      expect(all.filter((r) => r.deletedAt !== null)).toHaveLength(1);
+      expect(all.filter((r) => r.deletedAt === null)).toHaveLength(1);
+    });
+
+    it('block hides the bond and prevents further requests for the pair', async () => {
+      const { a, b, bond } = await seedAccepted();
+
+      asUser(b);
+      const blocked = await api(`/friends/${bond.id}/block`, { method: 'POST' });
+      expect(blocked.status).toBe(200);
+      expect((await rowById(bond.id)).status).toBe('blocked');
+
+      asUser(a);
+      const graphA = await (await api('/friends')).json<Graph>();
+      expect(graphA.friends.map((f) => f.user.id)).not.toContain(b.id);
+
+      // A blocked row is live + non-declined, so the pair index rejects a re-request.
+      const resend = await api('/friends/requests', { method: 'POST', body: { email: b.email } });
+      await expect(resend.json<SendBody>().then((r) => r.result)).resolves.toBe('duplicate');
+    });
+
+    it('rejects block and remove by an outsider (403), leaving the bond intact', async () => {
+      const { bond } = await seedAccepted();
+      const outsider = await seedUser({ name: 'Outsider' });
+      asUser(outsider);
+      expect((await api(`/friends/${bond.id}/block`, { method: 'POST' })).status).toBe(403);
+      expect((await api(`/friends/${bond.id}`, { method: 'DELETE' })).status).toBe(403);
+
+      const row = await rowById(bond.id);
+      expect(row.status).toBe('accepted');
+      expect(row.deletedAt).toBeNull();
+    });
+
+    it('returns 404 for an unknown id, and for removing an already-removed bond', async () => {
+      const { a, bond } = await seedAccepted();
+      asUser(a);
+
+      const unknown = randomUUID();
+      expect((await api(`/friends/${unknown}/block`, { method: 'POST' })).status).toBe(404);
+      expect((await api(`/friends/${unknown}`, { method: 'DELETE' })).status).toBe(404);
+
+      expect((await api(`/friends/${bond.id}`, { method: 'DELETE' })).status).toBe(200);
+      // The tombstone is no longer actionable.
+      expect((await api(`/friends/${bond.id}`, { method: 'DELETE' })).status).toBe(404);
+      expect((await api(`/friends/${bond.id}/block`, { method: 'POST' })).status).toBe(404);
+    });
+
+    it('returns 401 without a session', async () => {
+      asAnon();
+      const id = randomUUID();
+      expect((await api(`/friends/${id}/block`, { method: 'POST' })).status).toBe(401);
+      expect((await api(`/friends/${id}`, { method: 'DELETE' })).status).toBe(401);
+    });
+  });
+});

--- a/server/routes/friends.ts
+++ b/server/routes/friends.ts
@@ -1,0 +1,278 @@
+import { and, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm';
+import { Hono } from 'hono';
+
+import type { AppEnv } from '../context';
+import { db } from '../db';
+import { friendships, user } from '../db/schema';
+import { profile } from './shared';
+
+export const friends = new Hono<AppEnv>();
+
+/** Result of a send-request attempt, mirrored by the client's FriendRequestResult. */
+type SendResult = 'not_found' | 'self' | 'duplicate' | 'sent';
+
+/**
+ * postgres-js raises a unique-violation as an error with SQLSTATE 23505, but
+ * drizzle wraps it in a DrizzleQueryError whose `.cause` is the original — so
+ * walk the cause chain rather than reading `.code` off the top-level error.
+ */
+function isUniqueViolation(e: unknown): boolean {
+  let err: unknown = e;
+  for (let depth = 0; depth < 5 && err != null; depth++) {
+    if (typeof err === 'object' && (err as { code?: unknown }).code === '23505') return true;
+    err = (err as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/**
+ * GET /friends — the caller's social graph, oriented from their point of view.
+ * Every live (non-soft-deleted) friendship touching the caller is loaded, then
+ * partitioned by status and the caller's side of the row:
+ *   accepted                     -> friends
+ *   pending, caller is addressee -> incoming
+ *   pending, caller is requester -> outgoing
+ *   declined / blocked           -> excluded
+ * Each item carries the *counterpart* profile (never the caller's own).
+ */
+friends.get('/', async (c) => {
+  const me = c.get('user');
+  if (!me) return c.json({ error: 'Unauthorized' }, 401);
+
+  const rows = await db
+    .select()
+    .from(friendships)
+    .where(
+      and(
+        or(eq(friendships.requesterId, me.id), eq(friendships.addresseeId, me.id)),
+        isNull(friendships.deletedAt)
+      )
+    );
+
+  // Fetch the counterpart profiles in one round-trip.
+  const counterpartIds = [
+    ...new Set(rows.map((f) => (f.requesterId === me.id ? f.addresseeId : f.requesterId))),
+  ];
+  const counterpartRows = counterpartIds.length
+    ? await db.select().from(user).where(inArray(user.id, counterpartIds))
+    : [];
+  const byId = new Map(counterpartRows.map((u) => [u.id, u]));
+
+  type Item = {
+    friendshipId: string;
+    status: (typeof rows)[number]['status'];
+    createdAt: Date;
+    user: ReturnType<typeof profile>;
+  };
+  const friendsList: Item[] = [];
+  const incoming: Item[] = [];
+  const outgoing: Item[] = [];
+
+  for (const f of rows) {
+    const counterpartId = f.requesterId === me.id ? f.addresseeId : f.requesterId;
+    const counterpart = byId.get(counterpartId);
+    // FK guarantees the row exists; skip defensively rather than 500.
+    if (!counterpart) continue;
+    const item: Item = {
+      friendshipId: f.id,
+      status: f.status,
+      createdAt: f.createdAt,
+      user: profile(counterpart),
+    };
+    if (f.status === 'accepted') friendsList.push(item);
+    else if (f.status === 'pending' && f.addresseeId === me.id) incoming.push(item);
+    else if (f.status === 'pending' && f.requesterId === me.id) outgoing.push(item);
+    // declined / blocked are intentionally dropped
+  }
+
+  return c.json({ friends: friendsList, incoming, outgoing });
+});
+
+/**
+ * POST /friends/requests — send a friend request to a user by email.
+ * Returns `{ result }`, one of not_found | self | duplicate | sent. The
+ * unordered-pair unique index (ADR 0002) is the source of truth for duplicates:
+ * the app-level pre-check is an optimisation, and a concurrent insert that slips
+ * past it is caught as a 23505 and mapped to `duplicate` rather than a 500.
+ */
+friends.post('/requests', async (c) => {
+  const me = c.get('user');
+  if (!me) return c.json({ error: 'Unauthorized' }, 401);
+
+  let body: { email?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'A valid JSON body with an email is required.' }, 400);
+  }
+
+  const raw = body.email;
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return c.json({ error: 'An email is required.' }, 400);
+  }
+  const email = raw.trim();
+
+  // Guard self before touching the DB (case-insensitive).
+  if (email.toLowerCase() === me.email.toLowerCase()) {
+    return c.json({ result: 'self' satisfies SendResult });
+  }
+
+  const [target] = await db
+    .select()
+    .from(user)
+    .where(sql`lower(${user.email}) = ${email.toLowerCase()}`)
+    .limit(1);
+
+  if (!target) return c.json({ result: 'not_found' satisfies SendResult });
+  if (target.id === me.id) return c.json({ result: 'self' satisfies SendResult });
+
+  // Pre-check: any live friendship for the unordered pair, either direction.
+  const [existing] = await db
+    .select({ id: friendships.id })
+    .from(friendships)
+    .where(
+      and(
+        or(
+          and(eq(friendships.requesterId, me.id), eq(friendships.addresseeId, target.id)),
+          and(eq(friendships.requesterId, target.id), eq(friendships.addresseeId, me.id))
+        ),
+        ne(friendships.status, 'declined'),
+        isNull(friendships.deletedAt)
+      )
+    )
+    .limit(1);
+
+  if (existing) return c.json({ result: 'duplicate' satisfies SendResult });
+
+  try {
+    await db.insert(friendships).values({
+      requesterId: me.id,
+      addresseeId: target.id,
+      status: 'pending',
+    });
+  } catch (e) {
+    // Lost the race: the pair index rejected the second insert.
+    if (isUniqueViolation(e)) return c.json({ result: 'duplicate' satisfies SendResult });
+    throw e;
+  }
+
+  return c.json({ result: 'sent' satisfies SendResult });
+});
+
+/**
+ * Load a single friendship by id, or null when it is missing or has been
+ * soft-deleted (`deletedAt` set). Both cases map to 404 on the mutation routes:
+ * a removed bond is a tombstone the caller can no longer act on.
+ */
+async function loadLiveFriendship(id: string) {
+  const [row] = await db.select().from(friendships).where(eq(friendships.id, id)).limit(1);
+  if (!row || row.deletedAt) return null;
+  return row;
+}
+
+/** True when the caller is one of the two users the friendship connects. */
+function isParticipant(row: { requesterId: string; addresseeId: string }, meId: string): boolean {
+  return row.requesterId === meId || row.addresseeId === meId;
+}
+
+/**
+ * POST /friends/:id/accept — ADDRESSEE-ONLY. Only the user who *received* a
+ * pending request can answer it: the requester answering their own request, or
+ * an outsider, is 403; a missing or soft-deleted row is 404. Marks the bond
+ * accepted so both sides become mutual Witnesses (GET /friends surfaces the
+ * counterpart for each participant).
+ */
+friends.post('/:id/accept', async (c) => {
+  const me = c.get('user');
+  if (!me) return c.json({ error: 'Unauthorized' }, 401);
+
+  const row = await loadLiveFriendship(c.req.param('id'));
+  if (!row) return c.json({ error: 'Not found' }, 404);
+  if (row.addresseeId !== me.id) return c.json({ error: 'Forbidden' }, 403);
+  // Only a *pending* request can be answered (the spec transition is
+  // pending -> accepted). Refusing other states also stops a declined tombstone
+  // from being resurrected into a second live bond, which would collide with the
+  // ADR-0002 pair index.
+  if (row.status !== 'pending') return c.json({ error: 'Not found' }, 404);
+
+  await db
+    .update(friendships)
+    .set({ status: 'accepted', updatedAt: new Date() })
+    .where(eq(friendships.id, row.id));
+  return c.json({ ok: true });
+});
+
+/**
+ * POST /friends/:id/decline — ADDRESSEE-ONLY (same guard as accept). Marks the
+ * bond declined. The ADR-0002 pair index excludes declined rows, so the
+ * requester may send a fresh request later (the declined row stays as a
+ * tombstone alongside the new live one).
+ */
+friends.post('/:id/decline', async (c) => {
+  const me = c.get('user');
+  if (!me) return c.json({ error: 'Unauthorized' }, 401);
+
+  const row = await loadLiveFriendship(c.req.param('id'));
+  if (!row) return c.json({ error: 'Not found' }, 404);
+  if (row.addresseeId !== me.id) return c.json({ error: 'Forbidden' }, 403);
+  // Same as accept: only a pending request can be declined.
+  if (row.status !== 'pending') return c.json({ error: 'Not found' }, 404);
+
+  await db
+    .update(friendships)
+    .set({ status: 'declined', updatedAt: new Date() })
+    .where(eq(friendships.id, row.id));
+  return c.json({ ok: true });
+});
+
+/**
+ * POST /friends/:id/block — PARTICIPANT-ONLY. Either side may block the bond
+ * (an outsider is 403, missing/soft-deleted is 404). A blocked row stays live
+ * and non-declined, so it is still covered by the pair index: it hides the bond
+ * from GET /friends and blocks any further request for the pair.
+ */
+friends.post('/:id/block', async (c) => {
+  const me = c.get('user');
+  if (!me) return c.json({ error: 'Unauthorized' }, 401);
+
+  const row = await loadLiveFriendship(c.req.param('id'));
+  if (!row) return c.json({ error: 'Not found' }, 404);
+  if (!isParticipant(row, me.id)) return c.json({ error: 'Forbidden' }, 403);
+
+  try {
+    await db
+      .update(friendships)
+      .set({ status: 'blocked', updatedAt: new Date() })
+      .where(eq(friendships.id, row.id));
+  } catch (e) {
+    // Blocking a declined tombstone while a fresh live bond already exists for
+    // the pair would make two rows collide on the ADR-0002 pair index; report
+    // the conflict rather than surfacing a 500.
+    if (isUniqueViolation(e)) return c.json({ error: 'A live bond already exists for this pair.' }, 409);
+    throw e;
+  }
+  return c.json({ ok: true });
+});
+
+/**
+ * DELETE /friends/:id — PARTICIPANT-ONLY. Soft-delete: stamp `deletedAt` so the
+ * bond vanishes from GET /friends for both sides. An outsider is 403; a missing
+ * or already soft-deleted row is 404. Because the pair index ignores
+ * soft-deleted rows, either user may re-add the other afterwards — a fresh live
+ * row is created next to this tombstone (ADR-0002).
+ */
+friends.delete('/:id', async (c) => {
+  const me = c.get('user');
+  if (!me) return c.json({ error: 'Unauthorized' }, 401);
+
+  const row = await loadLiveFriendship(c.req.param('id'));
+  if (!row) return c.json({ error: 'Not found' }, 404);
+  if (!isParticipant(row, me.id)) return c.json({ error: 'Forbidden' }, 403);
+
+  const now = new Date();
+  await db
+    .update(friendships)
+    .set({ deletedAt: now, updatedAt: now })
+    .where(eq(friendships.id, row.id));
+  return c.json({ ok: true });
+});

--- a/server/routes/shared.ts
+++ b/server/routes/shared.ts
@@ -1,0 +1,25 @@
+/** Fields Better Auth stores on a user row that the profile shape reads. */
+type ProfileInput = {
+  id: string;
+  name: string;
+  email: string;
+  timezone?: string | null;
+  notificationTime?: string | null;
+  tintIndex?: number | null;
+};
+
+/**
+ * The profile shape the client's `User` type expects (`name` is the username).
+ * Shared by every route that returns a user (users.ts, friends.ts) so the wire
+ * shape stays identical across endpoints.
+ */
+export function profile(u: ProfileInput) {
+  return {
+    id: u.id,
+    username: u.name,
+    email: u.email,
+    timezone: u.timezone ?? 'UTC',
+    notificationTime: u.notificationTime ?? '08:00',
+    tintIndex: u.tintIndex ?? 0,
+  };
+}

--- a/server/routes/users.test.ts
+++ b/server/routes/users.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { api, asAnon, asUser, cleanupCreated, seedUser } from '../test/harness';
+
+// Smoke test for the test seam itself: one app.request() flows through routing,
+// the session-guard middleware, and the handler against the real local
+// Postgres. No new endpoints — it exercises the existing GET /users/me.
+describe('GET /users/me (session-guarded profile route)', () => {
+  let me: Awaited<ReturnType<typeof seedUser>>;
+
+  beforeEach(async () => {
+    me = await seedUser();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanupCreated();
+  });
+
+  it('returns 401 when the request is anonymous', async () => {
+    asAnon();
+    const { status } = await api('/users/me');
+    expect(status).toBe(401);
+  });
+
+  it('returns 200 with the profile shape when authenticated as the seeded user', async () => {
+    asUser(me);
+    const { status, json } = await api('/users/me');
+
+    expect(status).toBe(200);
+    await expect(json()).resolves.toEqual({
+      id: me.id,
+      username: me.name,
+      email: me.email,
+      timezone: 'UTC',
+      notificationTime: '08:00',
+      tintIndex: 0,
+    });
+  });
+});

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -4,6 +4,7 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../context';
 import { db } from '../db';
 import { user } from '../db/schema';
+import { profile } from './shared';
 
 const TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
 
@@ -14,25 +15,6 @@ function isValidTimezone(tz: string): boolean {
   } catch {
     return false;
   }
-}
-
-/** The profile shape the client's `User` type expects (`name` is the username). */
-function profile(u: {
-  id: string;
-  name: string;
-  email: string;
-  timezone?: string | null;
-  notificationTime?: string | null;
-  tintIndex?: number | null;
-}) {
-  return {
-    id: u.id,
-    username: u.name,
-    email: u.email,
-    timezone: u.timezone ?? 'UTC',
-    notificationTime: u.notificationTime ?? '08:00',
-    tintIndex: u.tintIndex ?? 0,
-  };
 }
 
 export const users = new Hono<AppEnv>();

--- a/server/test/harness.ts
+++ b/server/test/harness.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from 'node:crypto';
+
+import { inArray } from 'drizzle-orm';
+import { vi } from 'vitest';
+
+import { app } from '../app';
+import { auth } from '../auth';
+import { db } from '../db';
+import { friendships, user } from '../db/schema';
+
+type NewUser = typeof user.$inferInsert;
+type UserRow = typeof user.$inferSelect;
+
+// ── Request client ──────────────────────────────────────────────────────────
+// One app.request() call exercises routing + the CORS/session middleware +
+// the route handler together, against the real Hono app object.
+
+type ApiInit = {
+  method?: string;
+  body?: unknown;
+  token?: string;
+  headers?: Record<string, string>;
+};
+
+type ApiResult = {
+  res: Response;
+  status: number;
+  /** Parse the JSON body. Safe to call more than once. */
+  json: <T = unknown>() => Promise<T>;
+};
+
+export async function api(path: string, init: ApiInit = {}): Promise<ApiResult> {
+  const { method = 'GET', body, token, headers = {} } = init;
+  const finalHeaders: Record<string, string> = { ...headers };
+  const reqInit: RequestInit = { method };
+  if (body !== undefined) {
+    finalHeaders['Content-Type'] ??= 'application/json';
+    reqInit.body = JSON.stringify(body);
+  }
+  if (token) finalHeaders.Authorization = `Bearer ${token}`;
+  reqInit.headers = finalHeaders;
+
+  const res = await app.request('/api' + path, reqInit);
+  return {
+    res,
+    status: res.status,
+    json: <T = unknown>() => res.clone().json() as Promise<T>,
+  };
+}
+
+// ── Session mocks ───────────────────────────────────────────────────────────
+// app.ts resolves the caller via auth.api.getSession() on the auth singleton;
+// spying on it lets tests drive the guard without real cookies/tokens. Casts
+// go through `as any` because better-auth's inferred Session type is stricter
+// than the minimal shape the guard reads (session?.user).
+
+/** Authenticate the next request(s) as `u` until mocks are restored. */
+export function asUser(u: UserRow): void {
+  const session = {
+    id: `test-session-${u.id}`,
+    userId: u.id,
+    token: `test-token-${u.id}`,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  };
+  vi.spyOn(auth.api, 'getSession').mockResolvedValue({ user: u, session } as any);
+}
+
+/** Make the next request(s) anonymous until mocks are restored. */
+export function asAnon(): void {
+  vi.spyOn(auth.api, 'getSession').mockResolvedValue(null as any);
+}
+
+// ── Seeding + FK-safe cleanup ───────────────────────────────────────────────
+// Every row this harness creates is tracked by id so cleanup only ever touches
+// data the test made — never the pre-existing rows from manual testing.
+
+const createdUserIds: string[] = [];
+const createdFriendshipIds: string[] = [];
+
+/** Insert a real user row (unique id + email) and track it for cleanup. */
+export async function seedUser(overrides: Partial<NewUser> = {}): Promise<UserRow> {
+  const { id: overrideId, ...rest } = overrides;
+  const id = overrideId ?? randomUUID();
+  const [row] = await db
+    .insert(user)
+    .values({
+      id,
+      name: 'Test User',
+      email: `test-${id}@example.test`,
+      ...rest,
+    })
+    .returning();
+  createdUserIds.push(row.id);
+  return row;
+}
+
+/** Register a friendship id so cleanupCreated() removes it before its users. */
+export function trackFriendship(id: string): void {
+  createdFriendshipIds.push(id);
+}
+
+/**
+ * Delete everything this harness created, children before parents so foreign
+ * keys stay satisfied: tracked friendships first, then tracked users.
+ */
+export async function cleanupCreated(): Promise<void> {
+  if (createdFriendshipIds.length > 0) {
+    await db.delete(friendships).where(inArray(friendships.id, createdFriendshipIds));
+    createdFriendshipIds.length = 0;
+  }
+  if (createdUserIds.length > 0) {
+    await db.delete(user).where(inArray(user.id, createdUserIds));
+    createdUserIds.length = 0;
+  }
+}

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -1,0 +1,11 @@
+import { afterAll } from 'vitest';
+
+import { client } from '../db';
+
+// Vitest isolates each test file in its own module registry, so this `client`
+// is the same singleton the file's tests use. Closing the postgres-js pool
+// once the file's tests finish lets the worker exit instead of hanging on the
+// open socket. `timeout` forces any lingering connection shut after 5s.
+afterAll(async () => {
+  await client.end({ timeout: 5 });
+});

--- a/src/app/create.tsx
+++ b/src/app/create.tsx
@@ -16,7 +16,6 @@ import {
   Kicker,
   Small,
 } from '@/components/ui/type';
-import { apiEnabled } from '@/lib/api';
 import { useFriends, useStore } from '@/store/use-store';
 import { useTabs } from '@/store/use-tabs';
 import type { PactType } from '@/store/types';
@@ -294,27 +293,23 @@ export default function CreatePact() {
               }}
             >
               <Body color={colors.ink50} align="center">
-                {apiEnabled
-                  ? 'A pact needs a witness, and friend invites arrive with the server sync — pacts can’t be drafted just yet.'
-                  : 'A pact needs a witness — invite a friend first.'}
+                A pact needs a witness — invite one on the Friends tab first.
               </Body>
-              {!apiEnabled && (
-                <PressableScale
-                  onPress={() => {
-                    router.dismiss();
-                    setTab('friends');
-                  }}
-                  style={{
-                    borderWidth: 1.5,
-                    borderColor: colors.ink,
-                    borderRadius: radii.pill,
-                    paddingHorizontal: 18,
-                    paddingVertical: 11,
-                  }}
-                >
-                  <BodySemi>Find a witness</BodySemi>
-                </PressableScale>
-              )}
+              <PressableScale
+                onPress={() => {
+                  router.dismiss();
+                  setTab('friends');
+                }}
+                style={{
+                  borderWidth: 1.5,
+                  borderColor: colors.ink,
+                  borderRadius: radii.pill,
+                  paddingHorizontal: 18,
+                  paddingVertical: 11,
+                }}
+              >
+                <BodySemi>Find a witness</BodySemi>
+              </PressableScale>
             </View>
           )}
           <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 10 }}>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -153,3 +153,55 @@ export async function updateMe(
   const { data } = await call<ApiProfile>('/users/me', { method: 'PATCH', token, body: patch });
   return data;
 }
+
+/** One friendship oriented from the caller's side: the `user` is the counterpart. */
+export type ApiFriendItem = {
+  friendshipId: string;
+  status: 'pending' | 'accepted' | 'declined' | 'blocked';
+  createdAt: string;
+  user: ApiProfile;
+};
+
+/** GET /friends — the caller's social graph, partitioned server-side. */
+export async function listFriends(
+  token: string
+): Promise<{ friends: ApiFriendItem[]; incoming: ApiFriendItem[]; outgoing: ApiFriendItem[] }> {
+  const { data } = await call<{
+    friends: ApiFriendItem[];
+    incoming: ApiFriendItem[];
+    outgoing: ApiFriendItem[];
+  }>('/friends', { token });
+  return data;
+}
+
+/** POST /friends/requests — send a request by email; the server resolves the target. */
+export async function sendFriendRequestApi(
+  token: string,
+  email: string
+): Promise<{ result: 'not_found' | 'self' | 'duplicate' | 'sent' }> {
+  const { data } = await call<{ result: 'not_found' | 'self' | 'duplicate' | 'sent' }>(
+    '/friends/requests',
+    { method: 'POST', token, body: { email } }
+  );
+  return data;
+}
+
+/** POST /friends/:id/accept — the addressee accepts an incoming request. */
+export async function acceptFriendApi(token: string, friendshipId: string): Promise<void> {
+  await call(`/friends/${friendshipId}/accept`, { method: 'POST', token });
+}
+
+/** POST /friends/:id/decline — the addressee declines an incoming request. */
+export async function declineFriendApi(token: string, friendshipId: string): Promise<void> {
+  await call(`/friends/${friendshipId}/decline`, { method: 'POST', token });
+}
+
+/** POST /friends/:id/block — either participant blocks the bond. */
+export async function blockFriendApi(token: string, friendshipId: string): Promise<void> {
+  await call(`/friends/${friendshipId}/block`, { method: 'POST', token });
+}
+
+/** DELETE /friends/:id — either participant removes (soft-deletes) the bond. */
+export async function removeFriendApi(token: string, friendshipId: string): Promise<void> {
+  await call(`/friends/${friendshipId}`, { method: 'DELETE', token });
+}

--- a/src/screens/friends.tsx
+++ b/src/screens/friends.tsx
@@ -1,6 +1,6 @@
 import { router } from 'expo-router';
-import { useState } from 'react';
-import { ScrollView, TextInput, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import { RefreshControl, ScrollView, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, { FadeInDown, FadeOut } from 'react-native-reanimated';
 
@@ -11,9 +11,16 @@ import { Avatar } from '@/components/ui/avatar';
 import { CheckIcon, CloseIcon, MailIcon } from '@/components/ui/icons';
 import { PressableScale } from '@/components/ui/pressable-scale';
 import { Body, BodyBold, BodySemi, Heading, Kicker, Small } from '@/components/ui/type';
-import { apiEnabled } from '@/lib/api';
+import { apiEnabled, errorMessage } from '@/lib/api';
 import { fonts, colors, radii, shadows } from '@/theme/tokens';
-import { useFriends, useOutgoingRequests, usePendingRequests, useStore } from '@/store/use-store';
+import {
+  useFriends,
+  useOutgoingRequests,
+  usePendingRequests,
+  useStore,
+  type FriendRequestResult,
+} from '@/store/use-store';
+import { useTabs } from '@/store/use-tabs';
 
 export function FriendsScreen() {
   const insets = useSafeAreaInsets();
@@ -24,29 +31,63 @@ export function FriendsScreen() {
   const declineFriend = useStore((s) => s.declineFriend);
   const removeFriend = useStore((s) => s.removeFriend);
   const sendFriendRequest = useStore((s) => s.sendFriendRequest);
+  const refreshFriends = useStore((s) => s.refreshFriends);
   const pacts = useStore((s) => s.pacts);
   const blockFriend = useStore((s) => s.blockFriend);
   const [email, setEmail] = useState('');
   const [feedback, setFeedback] = useState<{ msg: string; ok: boolean } | null>(null);
   const [declineTarget, setDeclineTarget] = useState<{ id: string; name: string } | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const activeTab = useTabs((s) => s.tab);
 
-  const send = () => {
+  // Re-pull the social graph whenever the Friends tab becomes active (API mode
+  // only). All four tab scenes stay mounted (display-toggled), so there is no
+  // remount to hang a load on — keying off the active tab is what lets a request
+  // sent from another device appear when you switch back to this tab.
+  useEffect(() => {
+    if (apiEnabled && activeTab === 'friends') void refreshFriends();
+  }, [activeTab, refreshFriends]);
+
+  // Manual pull-to-refresh. refreshFriends() never throws, so no catch needed.
+  const onRefreshGraph = async () => {
+    setRefreshing(true);
+    await refreshFriends();
+    setRefreshing(false);
+  };
+
+  const send = async () => {
     if (!email.includes('@')) return;
-    const result = sendFriendRequest(email.trim());
-    const messages: Record<string, { msg: string; ok: boolean }> = {
+    const messages: Record<FriendRequestResult, { msg: string; ok: boolean }> = {
       sent: { msg: 'Request sent — they’ll see it next time they open My Pact.', ok: true },
       not_found: {
         msg: apiEnabled
-          ? 'No one with that email here yet — friend lookup arrives with the server sync.'
+          ? 'No one with that email has an account yet.'
           : 'No one with that email here yet — in this demo, try mia@mypact.app.',
         ok: false,
       },
       duplicate: { msg: 'You already have a request or friendship with them.', ok: false },
       self: { msg: 'You can’t witness yourself — that’s the whole point.', ok: false },
     };
-    setFeedback(messages[result]);
-    if (result === 'sent') setEmail('');
+    try {
+      const result = await sendFriendRequest(email.trim());
+      setFeedback(messages[result]);
+      if (result === 'sent') setEmail('');
+    } catch (e) {
+      // Server unreachable or errored — surface a clear message.
+      setFeedback({ msg: errorMessage(e), ok: false });
+    }
     setTimeout(() => setFeedback(null), 3200);
+  };
+
+  // accept / decline / block / remove now hit the server (async). Surface any
+  // failure with the same transient banner the send path uses.
+  const runFriendAction = async (action: () => Promise<void>) => {
+    try {
+      await action();
+    } catch (e) {
+      setFeedback({ msg: errorMessage(e), ok: false });
+      setTimeout(() => setFeedback(null), 3200);
+    }
   };
 
   return (
@@ -61,6 +102,15 @@ export function FriendsScreen() {
       }}
       showsVerticalScrollIndicator={false}
       keyboardShouldPersistTaps="handled"
+      refreshControl={
+        apiEnabled ? (
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefreshGraph}
+            tintColor={colors.ink50}
+          />
+        ) : undefined
+      }
     >
       <ScreenHeader kicker="Witnesses" title="Friends" />
 
@@ -147,7 +197,7 @@ export function FriendsScreen() {
                 <Small color={colors.ink50}>wants to witness your habits</Small>
               </View>
               <PressableScale
-                onPress={() => acceptFriend(friendship.id)}
+                onPress={() => runFriendAction(() => acceptFriend(friendship.id))}
                 accessibilityLabel={`Accept ${user.username}`}
                 style={{
                   width: 40,
@@ -229,7 +279,7 @@ export function FriendsScreen() {
                 <Small style={{ color: colors.white }}>Pact</Small>
               </PressableScale>
               <PressableScale
-                onPress={() => removeFriend(friendship.id)}
+                onPress={() => runFriendAction(() => removeFriend(friendship.id))}
                 accessibilityLabel={`Remove ${user.username}`}
                 style={{
                   paddingHorizontal: 12,
@@ -286,9 +336,7 @@ export function FriendsScreen() {
           >
             <Heading color={colors.ink50}>No witnesses yet</Heading>
             <Body color={colors.ink50} align="center">
-              {apiEnabled
-                ? 'Friend lookup arrives with the server sync. Your witnesses will appear here.'
-                : 'A pact needs two names. Invite someone above.'}
+              A pact needs two names. Invite someone by email above to get started.
             </Body>
           </View>
         )}
@@ -304,8 +352,9 @@ export function FriendsScreen() {
           </Body>
           <PressableScale
             onPress={() => {
-              if (declineTarget) declineFriend(declineTarget.id);
+              const id = declineTarget?.id;
               setDeclineTarget(null);
+              if (id) void runFriendAction(() => declineFriend(id));
             }}
             style={{
               borderWidth: 1.5,
@@ -319,8 +368,9 @@ export function FriendsScreen() {
           </PressableScale>
           <PressableScale
             onPress={() => {
-              if (declineTarget) blockFriend(declineTarget.id);
+              const id = declineTarget?.id;
               setDeclineTarget(null);
+              if (id) void runFriendAction(() => blockFriend(id));
             }}
             style={{
               backgroundColor: colors.failed,

--- a/src/screens/pacts.tsx
+++ b/src/screens/pacts.tsx
@@ -28,7 +28,8 @@ export function PactsScreen() {
   const visible = useMemo(() => {
     if (filter === 'active')
       return pacts.filter((p) => p.creatorUserId === me.id && p.status === 'active');
-    if (filter === 'keeping') return pacts.filter((p) => p.keeperUserId === me.id);
+    if (filter === 'keeping')
+      return pacts.filter((p) => p.keeperUserId === me.id && p.status === 'active');
     return pacts.filter((p) => p.creatorUserId === me.id && p.status !== 'active');
   }, [pacts, filter, me.id]);
 

--- a/src/store/use-store.ts
+++ b/src/store/use-store.ts
@@ -3,7 +3,16 @@ import { useMemo } from 'react';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
-import { apiEnabled } from '@/lib/api';
+import {
+  acceptFriendApi,
+  apiEnabled,
+  blockFriendApi,
+  declineFriendApi,
+  listFriends,
+  removeFriendApi,
+  sendFriendRequestApi,
+  type ApiProfile,
+} from '@/lib/api';
 import { gracePeriodKey, todayKey } from '@/lib/dates';
 import { reconcile } from '@/lib/engine';
 import { goalProgress } from '@/lib/streaks';
@@ -25,12 +34,17 @@ import type {
   PactType,
   User,
 } from '@/store/types';
+import { useAuth } from './use-auth';
 
 // Unique across launches: persisted entities keep their ids, so a plain
 // counter would collide after rehydration.
 let idCounter = 0;
 const nextId = (prefix: string) =>
   `${prefix}-${Date.now().toString(36)}-${(idCounter++).toString(36)}`;
+
+// In-flight guard for refreshFriends(): a mount effect and a post-send refresh
+// can fire close together; the second call no-ops until the first settles.
+let refreshing = false;
 
 export type CreatePactInput = {
   title: string;
@@ -68,11 +82,12 @@ type State = {
   checkIn: (pactId: string, opts?: { progressValue?: number; date?: string }) => void;
   createPact: (input: CreatePactInput) => Pact;
   cancelPact: (pactId: string) => void;
-  acceptFriend: (friendshipId: string) => void;
-  declineFriend: (friendshipId: string) => void;
-  blockFriend: (friendshipId: string) => void;
-  removeFriend: (friendshipId: string) => void;
-  sendFriendRequest: (email: string) => FriendRequestResult;
+  acceptFriend: (friendshipId: string) => Promise<void>;
+  declineFriend: (friendshipId: string) => Promise<void>;
+  blockFriend: (friendshipId: string) => Promise<void>;
+  removeFriend: (friendshipId: string) => Promise<void>;
+  sendFriendRequest: (email: string) => Promise<FriendRequestResult>;
+  refreshFriends: () => Promise<void>;
   markRead: (notificationId: string) => void;
   markAllRead: () => void;
   updateProfile: (update: ProfileUpdate) => void;
@@ -100,6 +115,24 @@ function freshState() {
     notifications: buildSeedNotifications(),
     remindersEnabled: true,
   };
+}
+
+// A mutual pact is two twins sharing one mutualPactId; voiding it must void
+// both. Heal any historical drift (one twin cancelled while the other stayed
+// active — from before cancelPact cascaded) on load, so a cancelled mutual
+// pact never lingers as active in "Keeping".
+function healMutualCancellation(pacts: Pact[]): Pact[] {
+  const cancelledPairs = new Set(
+    pacts
+      .filter((p) => p.status === 'cancelled' && p.isMutual && p.mutualPactId)
+      .map((p) => p.mutualPactId)
+  );
+  if (cancelledPairs.size === 0) return pacts;
+  return pacts.map((p) =>
+    p.isMutual && p.mutualPactId && p.status === 'active' && cancelledPairs.has(p.mutualPactId)
+      ? { ...p, status: 'cancelled' as const }
+      : p
+  );
 }
 
 export const useStore = create<State>()(
@@ -217,9 +250,18 @@ export const useStore = create<State>()(
         const pact = pacts.find((p) => p.id === pactId);
         const keeper = users.find((u) => u.id === pact?.keeperUserId)?.username ?? 'Your keeper';
         set({
-          pacts: pacts.map((p) =>
-            p.id === pactId ? { ...p, status: 'cancelled' as const } : p
-          ),
+          // Voiding a mutual pact voids BOTH twins — the friend's linked copy
+          // shares the same mutualPactId (different id), so cancelling only the
+          // tapped one left its partner lingering as active.
+          pacts: pacts.map((p) => {
+            const isTarget = p.id === pactId;
+            const isActiveTwin =
+              !!pact?.isMutual &&
+              !!pact.mutualPactId &&
+              p.mutualPactId === pact.mutualPactId &&
+              p.status === 'active';
+            return isTarget || isActiveTwin ? { ...p, status: 'cancelled' as const } : p;
+          }),
           notifications: pact
             ? [
                 {
@@ -236,7 +278,17 @@ export const useStore = create<State>()(
         });
       },
 
-      acceptFriend: (friendshipId) => {
+      acceptFriend: async (friendshipId) => {
+        if (apiEnabled) {
+          const token = useAuth.getState().token;
+          if (!token) throw new Error('You appear to be signed out. Sign in and try again.');
+          await acceptFriendApi(token, friendshipId);
+          // Notifications sync is out of scope: the API path pulls the fresh
+          // graph but emits no local notification (unlike the demo path below).
+          await get().refreshFriends();
+          return;
+        }
+
         const { friendships, users, notifications } = get();
         const f = friendships.find((x) => x.id === friendshipId);
         const requester = users.find((u) => u.id === f?.requesterId)?.username ?? 'A friend';
@@ -260,7 +312,15 @@ export const useStore = create<State>()(
         });
       },
 
-      declineFriend: (friendshipId) => {
+      declineFriend: async (friendshipId) => {
+        if (apiEnabled) {
+          const token = useAuth.getState().token;
+          if (!token) throw new Error('You appear to be signed out. Sign in and try again.');
+          await declineFriendApi(token, friendshipId);
+          await get().refreshFriends();
+          return;
+        }
+
         set({
           friendships: get().friendships.map((f) =>
             f.id === friendshipId ? { ...f, status: 'declined' as const } : f
@@ -268,7 +328,15 @@ export const useStore = create<State>()(
         });
       },
 
-      blockFriend: (friendshipId) => {
+      blockFriend: async (friendshipId) => {
+        if (apiEnabled) {
+          const token = useAuth.getState().token;
+          if (!token) throw new Error('You appear to be signed out. Sign in and try again.');
+          await blockFriendApi(token, friendshipId);
+          await get().refreshFriends();
+          return;
+        }
+
         // pending, accepted and declined can all transition to blocked
         set({
           friendships: get().friendships.map((f) =>
@@ -277,11 +345,29 @@ export const useStore = create<State>()(
         });
       },
 
-      removeFriend: (friendshipId) => {
+      removeFriend: async (friendshipId) => {
+        if (apiEnabled) {
+          const token = useAuth.getState().token;
+          if (!token) throw new Error('You appear to be signed out. Sign in and try again.');
+          await removeFriendApi(token, friendshipId);
+          await get().refreshFriends();
+          return;
+        }
+
         set({ friendships: get().friendships.filter((f) => f.id !== friendshipId) });
       },
 
-      sendFriendRequest: (email) => {
+      sendFriendRequest: async (email) => {
+        if (apiEnabled) {
+          const token = useAuth.getState().token;
+          if (!token) throw new Error('You appear to be signed out. Sign in and try again.');
+          const { result } = await sendFriendRequestApi(token, email.trim());
+          // Pull the new outgoing request into the local cache immediately.
+          if (result === 'sent') await get().refreshFriends();
+          return result;
+        }
+
+        // Demo mode: resolve entirely against the in-memory seed dataset.
         const { users, friendships, meId } = get();
         const me = users.find((u) => u.id === meId);
         if (me && me.email.toLowerCase() === email.toLowerCase()) return 'self';
@@ -308,6 +394,86 @@ export const useStore = create<State>()(
           ],
         });
         return 'sent';
+      },
+
+      refreshFriends: async () => {
+        if (!apiEnabled) return;
+        // A mount-effect load and a post-send refresh can overlap; let the
+        // first win and no-op the rest until it settles.
+        if (refreshing) return;
+        const token = useAuth.getState().token;
+        if (!token) return;
+        refreshing = true;
+        try {
+          const { friends, incoming, outgoing } = await listFriends(token);
+
+          const counterparts: User[] = [];
+          const seen = new Set<string>();
+          const cacheCounterpart = (p: ApiProfile) => {
+            if (seen.has(p.id)) return;
+            seen.add(p.id);
+            counterparts.push({
+              id: p.id,
+              username: p.username,
+              email: p.email,
+              timezone: p.timezone,
+              notificationTime: p.notificationTime,
+              tintIndex: p.tintIndex,
+            });
+          };
+
+          // ADR 0003: stitch every row's local side to the ME sentinel and cache
+          // the counterpart by its real server id, so the existing selectors
+          // (which locate "me" by matching ME) partition the graph correctly.
+          // requester/addressee here are synthetic — nothing client-side reads
+          // the server's real orientation.
+          const normalised: Friendship[] = [];
+          for (const item of friends) {
+            normalised.push({
+              id: item.friendshipId,
+              requesterId: ME,
+              addresseeId: item.user.id,
+              status: 'accepted',
+              createdAt: item.createdAt,
+            });
+            cacheCounterpart(item.user);
+          }
+          for (const item of incoming) {
+            normalised.push({
+              id: item.friendshipId,
+              requesterId: item.user.id,
+              addresseeId: ME,
+              status: 'pending',
+              createdAt: item.createdAt,
+            });
+            cacheCounterpart(item.user);
+          }
+          for (const item of outgoing) {
+            normalised.push({
+              id: item.friendshipId,
+              requesterId: ME,
+              addresseeId: item.user.id,
+              status: 'pending',
+              createdAt: item.createdAt,
+            });
+            cacheCounterpart(item.user);
+          }
+
+          // Preserve the local ME user as-is; replace the counterpart cache.
+          const meUser = get().users.find((u) => u.id === ME);
+          set({
+            friendships: normalised,
+            users: meUser ? [meUser, ...counterparts] : counterparts,
+          });
+        } catch (e) {
+          // Best-effort background sync: a failed refresh (e.g. an expired
+          // session returning 401) must never reject into its callers — the
+          // tab-focus / pull-to-refresh effects and the post-action refresh
+          // that runs after an action has already succeeded server-side.
+          if (__DEV__) console.warn('refreshFriends failed:', e);
+        } finally {
+          refreshing = false;
+        }
       },
 
       markRead: (notificationId) => {
@@ -384,7 +550,10 @@ export const useStore = create<State>()(
         if (p && (p.dataMode ?? 'demo') !== DATA_MODE) {
           return { ...current, ...freshState(), meId: ME };
         }
-        return { ...current, ...p };
+        const merged = { ...current, ...p };
+        // Repair mutual pacts whose twins drifted (one cancelled, one still
+        // active) before cancelPact voided both.
+        return { ...merged, pacts: healMutualCancellation(merged.pacts) };
       },
       migrate: (persisted, version) => {
         // API mode always restarts bare and account-scoped

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+
+// The server is the only thing under test here. Scoping `include` to server/**
+// keeps Vitest away from the React Native / Expo tree (JSX, native modules,
+// reanimated) which its esbuild-based transform is not set up to run.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['server/**/*.test.ts'],
+    // DB-backed tests share one real local Postgres; run files serially so
+    // seeded rows from one file never race another (mirrors humanlab's
+    // jest --runInBand).
+    fileParallelism: false,
+    // Integration tests against a live DB can flake on transient errors in CI;
+    // locally a failure should fail immediately. Mirrors humanlab's
+    // jest.retryTimes(2) under CI.
+    retry: process.env.CI ? 2 : 0,
+    // Close the postgres-js pool after each test file so the worker can exit.
+    setupFiles: ['./server/test/setup.ts'],
+  },
+});


### PR DESCRIPTION
…mode

Implements the server-side-friends PRD (#1) across its four slices, plus the repo's first automated-test harness. In API mode the Friends screen now works against the Hono/Better-Auth/Drizzle backend; offline demo mode is untouched.

Foundation (#2):
- `api` script loads .env.local strictly (--env-file); a missing env fails loud.
- First test setup: Vitest against the real local Supabase Postgres via app.request() — session resolver mocked (spy on auth.api.getSession), FK-safe cleanup, colocated *.test.ts, retry:CI?2:0. Smoke test on GET /users/me (401 anon / 200 mocked session).

Lookup, send & graph load (#3):
- Migration 0001: partial undirected unique index on friendships (LEAST/GREATEST, WHERE status<>'declined' AND deleted_at IS NULL) — ADR 0002.
- GET /friends (oriented, counterpart profile, excludes soft-deleted) and POST /friends/requests (not_found/self/duplicate/sent, case-insensitive, 23505 -> duplicate). Shared profile() helper.
- Client: listFriends, sendFriendRequestApi, ApiFriendItem.
- Store: async sendFriendRequest; in-flight-guarded refreshFriends stitching the local side to the 'u-me' sentinel (ADR 0003); selectors unchanged.

Accept / decline (#4) — Addressee-only:
- POST /friends/:id/accept & /decline (403 non-addressee, 404 unknown/non-pending, 401 anon); accept => mutual Witness; decline => re-request allowed.

Block / remove (#5) — participant-only:
- POST /friends/:id/block (blocked) and DELETE /friends/:id (soft-delete); re-add-after-remove; block prevents further requests.

Friends UX + hardening:
- refresh-on-tab-focus + pull-to-refresh; refreshFriends is best-effort (a failed/401 refresh warns instead of throwing an unhandled rejection).

Pact fixes (found during QA):
- cancelPact cascades to the mutual twin; "Keeping" shows active only; a load-time heal repairs mutual pacts whose twins drifted out of sync.

Docs: CONTEXT.md glossary; ADRs 0002 (unordered-pair index), 0003 (client identity sentinel).

Server route tests cover result mapping, the undirected-pair invariant, GET orientation, and full authorization. `npx tsc --noEmit` and `npx expo lint` pass.

Closes #1, #2, #3, #4, #5